### PR TITLE
Set bootjdk explicitly and remove setting bootjdk as javahome

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: "build-jdk-openj9"
 on: # rebuild any PRs and main branch changes
   # pull_request:
   push:
-#    branches-ignore:
- #     - '**'
+    branches-ignore:
+      - '**'
 
 jobs:
   build:

--- a/dist/index.js
+++ b/dist/index.js
@@ -3270,14 +3270,8 @@ function getBootJdk(version) {
         if (parseInt(bootJDKVersion) > 8) {
             let bootjdkJar;
             // TODO: issue open openj9,mac, 10 ga : https://api.adoptopenjdk.net/v3/binary/latest/10/ga/mac/x64/jdk/openj9/normal/adoptopenjdk doesn't work
-            // TODO: issue, openj9 linux jdk10 can not be the bootjdk for 11? 
-            if (`${bootJDKVersion}` === '10') {
-                if (`${targetOs}` === 'mac') {
-                    bootjdkJar = yield tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`);
-                }
-                else {
-                    bootjdkJar = yield tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/10/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`);
-                }
+            if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'mac') {
+                bootjdkJar = yield tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`);
             }
             else {
                 bootjdkJar = yield tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/${bootJDKVersion}/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`);
@@ -3286,18 +3280,13 @@ function getBootJdk(version) {
             if (`${targetOs}` === 'mac') {
                 yield exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=3`);
             }
+            else if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'linux') {
+                yield exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=2`); // TODO : issue open as this is packaged differently
+            }
             else {
                 yield exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`);
-                yield exec.exec(`ls`);
-                process.chdir('bootjdk');
-                yield exec.exec(`ls`);
-                process.chdir('bin');
-                yield exec.exec(`ls`);
-                yield exec.exec(`${workDir}/bootjdk/bin/java -version`);
             }
             yield io.rmRF(`${bootjdkJar}`);
-            // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
-            //  core.addPath(`${workDir}/bootjdk/bin`)
         }
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3284,8 +3284,8 @@ function getBootJdk(version) {
                 yield exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`);
             }
             yield io.rmRF(`${bootjdkJar}`);
-            core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`); //# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
-            core.addPath(`${workDir}/bootjdk/bin`);
+            // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+            //  core.addPath(`${workDir}/bootjdk/bin`)
         }
     });
 }
@@ -3328,7 +3328,7 @@ function getSource(openj9Version, usePersonalRepo) {
             openj9Parameters = `-openj9-repo=https://github.com/${openj9Repo}.git -openj9-branch=${openj9Branch}`;
         }
         yield exec.exec(`bash ./get_source.sh ${omrParameters} ${openj9Parameters}`);
-        yield exec.exec(`bash configure --with-freemarker-jar=${workDir}/freemarker.jar`);
+        yield exec.exec(`bash configure --with-freemarker-jar=${workDir}/freemarker.jar --with-boot-jdk=${workDir}/bootjdk`);
     });
 }
 function printJavaVersion(version, openj9Version) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3284,7 +3284,7 @@ function getBootJdk(version) {
             }
             else {
                 yield exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`);
-                yield exec.exec(`${workDir}/bootjkd/bin/java -version`);
+                yield exec.exec(`${workDir}/bootjdk/bin/java -version`);
             }
             yield io.rmRF(`${bootjdkJar}`);
             // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/dist/index.js
+++ b/dist/index.js
@@ -3270,12 +3270,16 @@ function getBootJdk(version) {
         if (parseInt(bootJDKVersion) > 8) {
             let bootjdkJar;
             // TODO: issue open openj9,mac, 10 ga : https://api.adoptopenjdk.net/v3/binary/latest/10/ga/mac/x64/jdk/openj9/normal/adoptopenjdk doesn't work
-            if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'mac') {
-                core.info("jdk10 , mac");
-                bootjdkJar = yield tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`);
+            // TODO: issue, openj9 linux jdk10 can not be the bootjdk for 11? 
+            if (`${bootJDKVersion}` === '10') {
+                if (`${targetOs}` === 'mac') {
+                    bootjdkJar = yield tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`);
+                }
+                else {
+                    bootjdkJar = yield tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/10/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`);
+                }
             }
             else {
-                core.info("jdkoth10er than , mac");
                 bootjdkJar = yield tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/${bootJDKVersion}/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`);
             }
             yield io.mkdirP('bootjdk');
@@ -3284,6 +3288,11 @@ function getBootJdk(version) {
             }
             else {
                 yield exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`);
+                yield exec.exec(`ls`);
+                process.chdir('bootjdk');
+                yield exec.exec(`ls`);
+                process.chdir('bin');
+                yield exec.exec(`ls`);
                 yield exec.exec(`${workDir}/bootjdk/bin/java -version`);
             }
             yield io.rmRF(`${bootjdkJar}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -3271,9 +3271,11 @@ function getBootJdk(version) {
             let bootjdkJar;
             // TODO: issue open openj9,mac, 10 ga : https://api.adoptopenjdk.net/v3/binary/latest/10/ga/mac/x64/jdk/openj9/normal/adoptopenjdk doesn't work
             if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'mac') {
+                core.info("jdk10 , mac");
                 bootjdkJar = yield tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`);
             }
             else {
+                core.info("jdkoth10er than , mac");
                 bootjdkJar = yield tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/${bootJDKVersion}/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`);
             }
             yield io.mkdirP('bootjdk');
@@ -3282,6 +3284,7 @@ function getBootJdk(version) {
             }
             else {
                 yield exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`);
+                yield exec.exec(`${workDir}/bootjkd/bin/java -version`);
             }
             yield io.rmRF(`${bootjdkJar}`);
             // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -119,8 +119,8 @@ async function getBootJdk(version: string): Promise<void> {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`)
     }
     await io.rmRF(`${bootjdkJar}`)
-    core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
-    core.addPath(`${workDir}/bootjdk/bin`)
+  // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+  //  core.addPath(`${workDir}/bootjdk/bin`)
   }
 }
 
@@ -163,7 +163,7 @@ async function getSource(
     openj9Parameters = `-openj9-repo=https://github.com/${openj9Repo}.git -openj9-branch=${openj9Branch}`
   }
   await exec.exec(`bash ./get_source.sh ${omrParameters} ${openj9Parameters}`)
-  await exec.exec(`bash configure --with-freemarker-jar=${workDir}/freemarker.jar`)
+  await exec.exec(`bash configure --with-freemarker-jar=${workDir}/freemarker.jar --with-boot-jdk=${workDir}/bootjdk`)
 }
 
 async function printJavaVersion(version: string, openj9Version: string): Promise<void> {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -119,7 +119,7 @@ async function getBootJdk(version: string): Promise<void> {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=3`)
     } else {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`)
-      await exec.exec(`${workDir}/bootjkd/bin/java -version`)
+      await exec.exec(`${workDir}/bootjdk/bin/java -version`)
     }
     await io.rmRF(`${bootjdkJar}`)
   // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -107,31 +107,20 @@ async function getBootJdk(version: string): Promise<void> {
   if (parseInt(bootJDKVersion) > 8) {
     let bootjdkJar
     // TODO: issue open openj9,mac, 10 ga : https://api.adoptopenjdk.net/v3/binary/latest/10/ga/mac/x64/jdk/openj9/normal/adoptopenjdk doesn't work
-    // TODO: issue, openj9 linux jdk10 can not be the bootjdk for 11? 
-    if (`${bootJDKVersion}` === '10') {
-      if (`${targetOs}` === 'mac') {
-        bootjdkJar = await tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`)
-      } else {
-        bootjdkJar = await tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/10/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`)
-      }
+    if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'mac') {
+      bootjdkJar = await tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`)
     } else {
       bootjdkJar = await tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/${bootJDKVersion}/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`)
     }
     await io.mkdirP('bootjdk')
     if (`${targetOs}` === 'mac') {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=3`)
+    } else if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'linux') {
+      await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=2`) // TODO : issue open as this is packaged differently
     } else {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`)
-      await exec.exec(`ls`)
-      process.chdir('bootjdk')
-      await exec.exec(`ls`)
-      process.chdir('bin')
-      await exec.exec(`ls`)
-      await exec.exec(`${workDir}/bootjdk/bin/java -version`)
     }
     await io.rmRF(`${bootjdkJar}`)
-  // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
-  //  core.addPath(`${workDir}/bootjdk/bin`)
   }
 }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -108,8 +108,10 @@ async function getBootJdk(version: string): Promise<void> {
     let bootjdkJar
     // TODO: issue open openj9,mac, 10 ga : https://api.adoptopenjdk.net/v3/binary/latest/10/ga/mac/x64/jdk/openj9/normal/adoptopenjdk doesn't work
     if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'mac') {
+      core.info("jdk10 , mac")
       bootjdkJar = await tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`)
     } else {
+      core.info("jdkoth10er than , mac")
       bootjdkJar = await tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/${bootJDKVersion}/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`)
     }
     await io.mkdirP('bootjdk')
@@ -117,6 +119,7 @@ async function getBootJdk(version: string): Promise<void> {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=3`)
     } else {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`)
+      await exec.exec(`${workDir}/bootjkd/bin/java -version`)
     }
     await io.rmRF(`${bootjdkJar}`)
   // core.exportVariable('JAVA_HOME', `${workDir}/bootjdk`)//# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -107,11 +107,14 @@ async function getBootJdk(version: string): Promise<void> {
   if (parseInt(bootJDKVersion) > 8) {
     let bootjdkJar
     // TODO: issue open openj9,mac, 10 ga : https://api.adoptopenjdk.net/v3/binary/latest/10/ga/mac/x64/jdk/openj9/normal/adoptopenjdk doesn't work
-    if (`${bootJDKVersion}` === '10' && `${targetOs}` === 'mac') {
-      core.info("jdk10 , mac")
-      bootjdkJar = await tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`)
+    // TODO: issue, openj9 linux jdk10 can not be the bootjdk for 11? 
+    if (`${bootJDKVersion}` === '10') {
+      if (`${targetOs}` === 'mac') {
+        bootjdkJar = await tc.downloadTool(`https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz`)
+      } else {
+        bootjdkJar = await tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/10/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`)
+      }
     } else {
-      core.info("jdkoth10er than , mac")
       bootjdkJar = await tc.downloadTool(`https://api.adoptopenjdk.net/v3/binary/latest/${bootJDKVersion}/ga/${targetOs}/x64/jdk/openj9/normal/adoptopenjdk`)
     }
     await io.mkdirP('bootjdk')
@@ -119,6 +122,11 @@ async function getBootJdk(version: string): Promise<void> {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=3`)
     } else {
       await exec.exec(`sudo tar -xzf ${bootjdkJar} -C ./bootjdk --strip=1`)
+      await exec.exec(`ls`)
+      process.chdir('bootjdk')
+      await exec.exec(`ls`)
+      process.chdir('bin')
+      await exec.exec(`ls`)
       await exec.exec(`${workDir}/bootjdk/bin/java -version`)
     }
     await io.rmRF(`${bootjdkJar}`)


### PR DESCRIPTION
Set bootjdk explicitly and remove setting bootjdk as javahome

Workround for jdk11 bootjdk package issue with linux